### PR TITLE
test(macos-13): use/suggest linker option for gcc7-9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,6 @@ jobs:
           - {compiler: gcc, version:  8}
           - {compiler: gcc, version:  7}
           - {compiler: gcc, version:  6}
-          # {compiler: gcc, version:  5}
         include:
           - {os: ubuntu-20.04, toolchain: {compiler: intel, version: '2023.2'}}
           - {os: ubuntu-20.04, toolchain: {compiler: intel, version: '2022.2.1'}}
@@ -146,7 +145,19 @@ jobs:
           FC: ${{ steps.setup-fortran.outputs.fc }}
           CC: ${{ steps.setup-fortran.outputs.cc }}
         run: |
-          ${{ env.FC }} -o hw hw.f90
+          # macos-13 / gcc 7-9 compatibility workaround
+          args=""
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            if [[ $(sw_vers -productVersion) == 13* ]] && \
+               [[ ${{ matrix.toolchain.compiler }} == "gcc" ]] && \
+               [[ ${{ matrix.toolchain.version }} =~ ^(7|8|9)$ ]]
+            then
+              args="-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib"
+            fi
+          fi
+          args="$args -o hw hw.f90"
+
+          ${{ env.FC }} $args
           output=$(./hw '2>&1')
           [[ "$output" == *"hello world"* ]] && echo "$output" || (echo "Unexpected output: $output"; exit 1)
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Support for the GCC toolchain varies across GitHub-hosted runner images.
 
 **Note:** version 13 of the GNU toolchain is not yet available on Windows.
 
+**Note:** on `macos-13`, gcc 7-9 require flag `-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib`.
+
 Supported Intel toolchains:
 
 | runner    | compiler       | version |
@@ -108,7 +110,7 @@ Supported Intel toolchains:
 | windows-\* | intel | 2023.2, 2023.1, 2023.0, 2022.2.0, 2022.1.0 |
 | windows-\* | intel-classic | 2021.10.0, 2021.9.0, 2021.8.0, 2021.7.0, 2021.6.0 |
 
-**Note:** on macOS the `intel`/`ifx` compiler option is not supported, only `intel-classic` with the `ifort` compiler.
+**Note:** on macOS `ifx` is not supported, so the `intel` option redirects to `intel-classic` (`ifort`).
 
 ## License
 


### PR DESCRIPTION
* close #39
* needs `-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib`
* update `.github/workflows/test.yml`
* document in `README.md`
* c.f.
  * https://developer.apple.com/forums/thread/666700
  * https://community.intel.com/t5/Intel-Fortran-Compiler/New-macOS-Big-Sur-return-quot-ld-library-not-found-for-lSystem/m-p/1235041/highlight/true#M153102