### PR TITLE
Fix issue with installation of gfortran 11

### DIFF
--- a/setup-fortran.sh
+++ b/setup-fortran.sh
@@ -98,10 +98,7 @@ install_gcc_choco()
     echo "GCC $version already installed"
   else
     # otherwise hide preinstalled mingw compilers
-    mkdir "$RUNNER_TEMP/mingw64"
-    mv /c/mingw64/bin/gfortran "$RUNNER_TEMP/mingw64/gfortran"
-    mv /c/mingw64/bin/gcc "$RUNNER_TEMP/mingw64/gcc"
-    mv /c/mingw64/bin/g++ "$RUNNER_TEMP/mingw64/g++"
+    mv /c/mingw64 "$RUNNER_TEMP/"
     # ...and install selected version
     case $version in
       13)


### PR DESCRIPTION
In my repo I had issues running a program compiled with gfortran 11 in CI. The problem turned out to be that it was successfully compiled with gfortran 11, but it was linking against the wrong libgfortran-5.dll at runtime. It was linking to the one in /c/mingw64/bin, which is from gfortran 12 which is installed by default in the Windows 2022 image.

The simple solution is to move the entire mingw64 folder instead of just a few files.

For reference here is a minimal program that demonstrates the issue. If you compile this with gfortran 11 and then try to make sure that libgfortran-5.dll from gfortran 12 is on the search path ahead of the one from gfortran 11, you will get a segfault. I don't think it's necessary to make a regression test since the entire folder is now moved.

```fortran

program bobyqa_exmp
implicit none

logical :: parent_logical_array(20)
integer(4), allocatable :: locations(:)

locations = true_locations(parent_logical_array)
print *, "hello world"

contains

function true_locations(logical_array) result(location_array)
implicit none
logical, intent(in) :: logical_array(:)
integer(4), allocatable :: location_array(:)
integer(4) :: n, monotone_array(size(logical_array))
n = count(logical_array)
allocate(location_array(1:n))
location_array = pack(monotone_array, mask=logical_array)

end function true_locations
end program bobyqa_exmp
```