### PR TITLE
fix(gcc/macos): don't meddle with lib locations

### DIFF
--- a/setup-fortran.sh
+++ b/setup-fortran.sh
@@ -60,20 +60,6 @@ install_gcc_brew()
     fi
   fi
 
-  # link lib dir for previous GCC versions to avoid missing .dylib issues
-  for (( i=13; i>4; i-- ))
-  do
-    gcc_lib_path="/usr/local/opt/gcc/lib/gcc/$i"
-    if [ -d $gcc_lib_path ]; then
-      echo "found $gcc_lib_path"
-      for (( j=$i; j>4; j-- ))
-      do
-        ln -fs /usr/local/opt/gcc/lib/gcc/$i /usr/local/opt/gcc/lib/gcc/$j
-      done
-      break
-    fi
-  done
-
   export FC="gfortran"
   export CC="gcc"
   export CXX="g++"


### PR DESCRIPTION
Bad idea carried in from [modflowpy/install-gfortran-action](https://github.com/modflowpy/install-gfortran-action/blob/55cad0f10fa0804b017a6d0169c4d4b5518b30fd/action.yml#L29), likely behind #32, blame is mine.

@gha3mi @jalvesz it would be good to confirm if pointing workflows at `wpbonelli/setup-fortran@macos-fix` solves the problem. Or provided a repo link I can fork and test