### PR TITLE
fix(mac/gcc): brew doesn't create unversioned gcc symlink

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,15 +186,15 @@ jobs:
           fi
 
       - name: Update README
-        if: ${{ steps.diff.outputs.diff == 'true' && github.event_name == 'push' }}
+        if: ${{ steps.diff.outputs.diff == 'true' }}
         run: python .github/compat/update_compat_table.py ".github/compat/compat.md" "README.md"
 
       - name: Print README diff
-        if: ${{ steps.diff.outputs.diff == 'true' && github.event_name == 'push' }}
+        if: ${{ steps.diff.outputs.diff == 'true' }}
         run: git diff README.md
 
       - name: Create pull request
-        if: ${{ steps.diff.outputs.diff == 'true' && github.event_name == 'push' }}
+        if: ${{ steps.diff.outputs.diff == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/setup-fortran.sh
+++ b/setup-fortran.sh
@@ -46,18 +46,15 @@ install_gcc_brew()
   brew link gcc@${version}
 
   os_ver=$(sw_vers -productVersion | cut -d'.' -f1)
-  # brew link doesn't create aliases without version numbers before gcc 13
-  if (( "$version" < 13 )); then
-    # default homebrew bin dir changed with macos 14
-    if (( "$os_ver" > 13 )); then
-      ln -fs /opt/homebrew/bin/gfortran-${version} /usr/local/bin/gfortran
-      ln -fs /opt/homebrew/bin/gcc-${version} /usr/local/bin/gcc
-      ln -fs /opt/homebrew/bin/g++-${version} /usr/local/bin/g++
-    else
-      ln -fs /usr/local/bin/gfortran-${version} /usr/local/bin/gfortran
-      ln -fs /usr/local/bin/gcc-${version} /usr/local/bin/gcc
-      ln -fs /usr/local/bin/g++-${version} /usr/local/bin/g++
-    fi
+  # default homebrew bin dir changed with macos 14
+  if (( "$os_ver" > 13 )); then
+    ln -fs /opt/homebrew/bin/gfortran-${version} /usr/local/bin/gfortran
+    ln -fs /opt/homebrew/bin/gcc-${version} /usr/local/bin/gcc
+    ln -fs /opt/homebrew/bin/g++-${version} /usr/local/bin/g++
+  else
+    ln -fs /usr/local/bin/gfortran-${version} /usr/local/bin/gfortran
+    ln -fs /usr/local/bin/gcc-${version} /usr/local/bin/gcc
+    ln -fs /usr/local/bin/g++-${version} /usr/local/bin/g++
   fi
 }
 


### PR DESCRIPTION
Homebrew creates an unversioned symlink for `gfortran` when gcc@13 is installed, but not for `gcc` or `g++`. Might as well always create them regardless of version installed. Also the bot-created PR to update the README was not getting triggered when `test.yml` runs in reporting mode.