### PR TITLE
ci: don't trigger when tags are pushed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   push:
     paths-ignore:
       - '**.md'
+    tags-ignore:
+      - v**
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Tests already run when changes merge to `main`, no need to repeat for tags