### PR TITLE
fix(macOS/intel): fallback to intel-classic, bump default intel version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,11 @@ runs:
         compiler=${COMPILER:-gcc}
         platform=$(uname -s | tr '[:upper:]' '[:lower:]')
 
+        if [[ "$RUNNER_OS" == "macOS" ]] && [[ "$compiler" == "intel" ]]; then
+          echo "Compiler 'intel' not supported on macOS, falling back to 'intel-classic'"
+          compiler="intel-classic"
+        fi
+
         case $compiler in
           gcc)
             version=${VERSION:-13}
@@ -67,7 +72,7 @@ runs:
             install_intel $platform true
             ;;
           intel)
-            version=${VERSION:-2023.2.0}
+            version=${VERSION:-2024.0}
             install_intel $platform false
             ;;
           nvidia-hpc)


### PR DESCRIPTION
* close #69 
* fall back to `intel-classic` on macOS if `intel` selected
* README suggested we already did this but evidently not
* also, bump default `intel` version to 2024.0