### PR TITLE
include mkl libraries for intel on linux and MacOS

### DIFF
--- a/.github/actions/test-mkl/action.yml
+++ b/.github/actions/test-mkl/action.yml
@@ -1,0 +1,56 @@
+name: Test mkl
+description: Test installation of mkl libraries
+inputs:
+  compiler:
+    description: "Toolchain or compiler to install"
+    required: true
+  version:
+    description: "Version of toolchain or compiler"
+    required: true
+  install_mkl: 
+    description: "If MKL should be installed along with the compiler"
+    required: false
+    default: "false"
+runs:
+  using: "composite"
+  steps:
+    - name: Test compile and link mkl (bash)
+      working-directory: test
+      shell: bash
+      run: |
+        # check settings if mkl tests should be run
+        # mkl cannot be installed for 2021.5 on macos;
+        # and for macos-14 also not 2021.6-2021.9
+        mkl_tests=true
+        echo "$RUNNER_OS"
+        if [[ "${{ inputs.compiler }}" =~ "gcc" ]]; then mkl_tests=false; fi
+        if [[ "${{ inputs.compiler }}" =~ "lfortran" ]]; then mkl_tests=false; fi
+        if [[ "${{ inputs.compiler }}" =~ "nvidia" ]]; then mkl_tests=false; fi
+        if [[ "${{ inputs.install_mkl }}" == "false" ]]; then mkl_tests=false; fi
+        if [[ "${{ inputs.version }}" == "2021.5" ]] && [[ "$RUNNER_OS" == "macOS" ]]; then mkl_tests=false; fi
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          macos_version=$(sw_vers | grep "ProductVersion")
+          echo "$macos_version"
+          if [[ "$macos_version" =~ "14." ]] && [[ "${{ inputs.version }}" == '2021.6' || "${{ inputs.version }}" == '2021.7' || "${{ inputs.version }}" == '2021.7.1' || "${{ inputs.version }}" == '2021.8' ]]; then 
+            mkl_tests=false
+          fi
+        fi
+
+        # # now we know if we should, run the tests
+        if $mkl_tests; then
+         if [ "$RUNNER_OS" == "macOS" ]; then
+           MKLLIB="$MKLROOT/lib"
+           export DYLD_LIBRARY_PATH="$MKLLIB:$DYLD_LIBRARY_PATH"
+         elif [ "$RUNNER_OS" == "Linux" ]; then
+           MKLLIB="$MKLROOT/latest/lib/intel64"
+           export LD_LIBRARY_PATH="$MKLLIB:$LD_LIBRARY_PATH"
+         fi
+         linking="-L$MKLLIB -lmkl_intel_lp64 -lmkl_sequential -lmkl_core" 
+         # hello world with blas call program
+         ${{ env.FC }} $args $linking -o hw_mkl hw_mkl.f90
+         output=$(./hw_mkl '2>&1')
+         [[ "$output" == *"hello world   9.00000000000000"* ]] && echo "$output" || (echo "Unexpected Fortran program 'hw_mkl' output: $output"; exit 1)
+         rm hw_mkl
+        else
+          echo "Skipping MKL tests"
+        fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - main
       - develop*
+      - math
     paths-ignore:
       - '**.md'
   schedule:
@@ -74,6 +75,7 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
+          install_mkl: true
 
       # - name: Debug with tmate
       #   uses: mxschmitt/action-tmate@v3
@@ -85,6 +87,17 @@ jobs:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
       
+      - name: Test MKL libraries
+        # we could also exclude 2021.5 for all macos versions here
+        # this needs refactoring at some point - should the install
+        # fail if no mkl version exists?
+        if: steps.setup-fortran.outcome == 'success' && runner.os != 'windows' 
+        uses: ./.github/actions/test-mkl
+        with:
+          compiler: ${{ matrix.toolchain.compiler }}
+          version: ${{ matrix.toolchain.version }}
+          install_mkl: true
+
       - name: Test C compiler
         continue-on-error: true
         if: needs.options.outputs.mode == 'report' && steps.setup-fortran.outcome == 'success'

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ jobs:
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}
+          install_mkl: "true"
 
       - run: |
           ${{ env.FC }} ... # environment vars FC, CC, and CXX are set
@@ -69,6 +70,7 @@ jobs:
   - *lfortran* for `lfortran`
   - *nvidia-hpc* for `nvfortran`
 - *version*: Version of the compiler toolchain. See [runner compatibility](#runner-compatibility) charts below.
+- *install_mkl*: If MKL libraries should be installed alongsider the intel compiler. Defaults to `false`.
 
 
 ## Outputs
@@ -118,6 +120,8 @@ Toolchain support varies across GitHub-hosted runner images.
 **Note:** Intel's `ifx` compiler is not supported on macOS, so the `intel` option redirects to `intel-classic` (`ifort`).
 
 **Note:** LFortran is currently only discoverable by name with `bash` on Windows, see [here for context](https://github.com/fortran-lang/setup-fortran/pull/57#issuecomment-2021605094).
+
+**Note:** MKL libraries can only be installed for the Intel Fortran compiler, and only on linux and MacOS operating systems; with the exception of intel-classic 2021.5, for which no compatible library is available.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Setup Fortran"
+name: "Setup Fortran and math libraries"
 description: "Setup Fortran compiler and toolchain"
 inputs:
   compiler:
@@ -8,6 +8,10 @@ inputs:
   version:
     description: "Version of toolchain or compiler"
     required: false
+  install_mkl:
+    description: "If MKL should be installed along with the compiler"
+    required: false
+    default: "false"
 outputs:
   fc:
     description: "Path to Fortran compiler"
@@ -68,6 +72,7 @@ runs:
       env:
         COMPILER: ${{ inputs.compiler }}
         VERSION: ${{ inputs.version }}
+        INSTALL_MKL: ${{ inputs.install_mkl }}
       run: |
         action_path=$(echo '/${{ github.action_path }}' | sed -e 's/\\/\//g' -e 's/://')
         source "$action_path/setup-fortran.sh"
@@ -87,11 +92,11 @@ runs:
             ;;
           intel-classic)
             version=${VERSION:-2023.2.0}
-            install_intel $platform true
+            install_intel $platform true ${{ inputs.install_mkl }}
             ;;
           intel)
             version=${VERSION:-2024.1}
-            install_intel $platform false
+            install_intel $platform false ${{ inputs.install_mkl }}
             ;;
           nvidia-hpc)
             version=${VERSION:-23.11}
@@ -151,6 +156,7 @@ runs:
         echo FC=$FC>>$GITHUB_ENV
         echo CC=$CC>>$GITHUB_ENV
         echo CXX=$CXX>>$GITHUB_ENV
+        echo "MKLLIB=$MKLLIB" >> $GITHUB_ENV
 
         # set fpm env vars
         echo FPM_FC=$FC>>$GITHUB_ENV

--- a/install-intel-macos.sh
+++ b/install-intel-macos.sh
@@ -1,0 +1,21 @@
+install_mkl=$1
+MACOS_URL=$2
+if [ "$MACOS_URL" == "" ]; then
+  echo "ERROR: MACOS URL is empty - please check the version mapping for mkl/intel compiler"
+  echo "SKIPPING MKL/intel installation..."
+elif [ "$MACOS_URL" == "2021.5" ] and $install_mkl; then
+  echo "ERROR: MKL not available for this intel compiler version"
+  echo "SKIPPING MKL installation..."
+else
+  require_fetch
+  $fetch $MACOS_URL > m_BASE_HPC_Kit.dmg
+  hdiutil verify m_BASE_HPC_Kit.dmg
+  hdiutil attach m_BASE_HPC_Kit.dmg
+  sudo /Volumes/"$(basename "$MACOS_URL" .dmg)"/bootstrapper.app/Contents/MacOS/bootstrapper -s \
+    --action install \
+    --eula=accept \
+    --continue-with-optional-error=yes \
+    --log-dir=.
+  hdiutil detach /Volumes/"$(basename "$MACOS_URL" .dmg)" -quiet
+  rm m_BASE_HPC_Kit.dmg
+fi

--- a/test/hw_mkl.f90
+++ b/test/hw_mkl.f90
@@ -1,0 +1,13 @@
+program hello
+  implicit none
+  double precision, dimension(3):: a, b
+  double precision:: c
+  double precision:: DDOT
+  
+  a = (/ 3.D0, 3.D0, 3.D0 /)
+  b = (/ 1.D0, 1.D0, 1.D0 /)
+
+  c = DDOT(3, a, 1, b, 1)
+  
+  print *, "hello world", c
+end program hello


### PR DESCRIPTION
- mkl libraries included for most MacOS versions
- mkl libraries included for all linux versions
- new test for mkl installation
- currently is not the default, the mkl test is run conditionally. With the inclusion of math libraries for more compilers+OS, the tests should run as default