### PR TITLE
chore: bump intel and lfortran default versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,7 @@ runs:
             install_intel $platform true
             ;;
           intel)
-            version=${VERSION:-2024.0}
+            version=${VERSION:-2024.1}
             install_intel $platform false
             ;;
           nvidia-hpc)
@@ -98,7 +98,7 @@ runs:
             install_nvidiahpc $platform
             ;;
           lfortran)
-            version=${VERSION:-0.30.0}
+            version=${VERSION:-0.33.0}
             install_lfortran $platform
             ;;
           *)


### PR DESCRIPTION
* intel 2024.0 -> 2024.1
* lfortran 0.30.0 -> 0.33.0 &mdash; considered 0.34.0 but the [conda pkg](https://anaconda.org/conda-forge/lfortran) for osx-64 is still on 0.33.1