### PR TITLE
fix(oneapi): use root environment activation script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -123,9 +123,7 @@ runs:
       run: |
         ver | findstr /i "10\.0\.17" && set VS2019INSTALLDIR=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
         ver | findstr /i "10\.0\.20" && set VS2022INSTALLDIR=C:\Program Files\Microsoft Visual Studio\2022\Enterprise
-        for /f "tokens=* usebackq" %%f in (`dir /b "%ONEAPI_ROOT%\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST=%%f"
-        :: this script fails when install location is not the default
-        call "%ONEAPI_ROOT%\compiler\%LATEST%\env\vars.bat"
+        call "%ONEAPI_ROOT%\setvars.bat"
         set | findstr /c:"oneAPI" >> "%GITHUB_ENV%"
 
     - name: Set outputs and env vars


### PR DESCRIPTION
Possible fix for #56. The issue seems like [incomplete oneapi environment activation](https://github.com/fortran-lang/fpm/discussions/717#discussioncomment-3091462). Previously we ran the activation script for compiler components only*. Run the root activation script instead.

@jalvesz @minhqdao let me know if pointing your workflows at this PR branch resolves the issue.

*This was carried over from https://github.com/modflowpy/install-intelfortran-action/blob/b874d3a869fb226ca5f02b4fbaffb3af7a8e6813/action.yml#L223. There was a reason we originally opted against the root activation script, but I don't recall what it was.