### PR TITLE
chore: support gcc14 (mac/linux), bump default intel version

### DIFF
--- a/.github/compat/matrix.yml
+++ b/.github/compat/matrix.yml
@@ -1,16 +1,14 @@
 os:
+  - ubuntu-24.04
   - ubuntu-22.04
-  - ubuntu-20.04
   - macos-14
   - macos-13
   - windows-2022
   - windows-2019
 toolchain:
+  - {compiler: gcc, version: 14}
   - {compiler: gcc, version: 13}
   - {compiler: gcc, version: 12}
-  - {compiler: gcc, version: 11}
-  - {compiler: gcc, version: 10}
-  - {compiler: gcc, version:  9}
   - {compiler: intel, version: '2025.0'}
   - {compiler: intel, version: '2024.1'}
   - {compiler: intel, version: '2024.0'}
@@ -90,10 +88,3 @@ exclude:
     toolchain: {compiler: nvidia-hpc}
   - os: windows-2019
     toolchain: {compiler: nvidia-hpc}
-  # gcc<=10 not available for ARM mac
-  - os: macos-14
-    toolchain: {compiler: gcc, version: 8}
-  - os: macos-14
-    toolchain: {compiler: gcc, version: 9}
-  - os: macos-14
-    toolchain: {compiler: gcc, version: 10}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,9 +114,9 @@ jobs:
 
       - name: Upload compatibility report
         if: needs.options.outputs.mode == 'report'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: compat
+          name: compat-${{ matrix.os }}-${{ matrix.toolchain.compiler }}-${{ matrix.toolchain.version }}
           path: compat/*.csv
   
   compat:
@@ -143,10 +143,11 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Download reports
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: compat
+          pattern: compat-*
           path: compat
+          merge-multiple: true
 
       - name: Concatenate reports
         run: |
@@ -160,7 +161,7 @@ jobs:
           cat compat.md
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: compat
           path: |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain:
           - {compiler: gcc, version: 13}
-          - {compiler: intel, version: '2023.2'}
+          - {compiler: intel, version: '2025.0'}
           - {compiler: intel-classic, version: '2021.10'}
           - {compiler: nvidia-hpc, version: '23.11'}
         include:

--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,7 @@ runs:
             install_intel $platform true
             ;;
           intel)
-            version=${VERSION:-2024.1}
+            version=${VERSION:-2025.0}
             install_intel $platform false
             ;;
           nvidia-hpc)


### PR DESCRIPTION
* support gcc 14 on Linux and macOS &mdash; mingw14 not yet available from choco on Windows
* bump default intel version to 2025.0
* drop ubuntu 20.04 from test matrix (EOL)
* drop gcc < 11 from test matrix (EOL)
* add ubuntu 24.04 to test matrix
* update actions versions