### PR TITLE
Fix intel compiler installation when "assume yes" is not set as an `apt` default

### DIFF
--- a/setup-fortran.sh
+++ b/setup-fortran.sh
@@ -350,11 +350,11 @@ install_intel_apt()
   # c/cpp compiler package names changed with 2024+
   case $version in
     2024* | 2025*)
-      sudo apt-get install \
+      sudo apt-get install -y \
         intel-oneapi-compiler-{fortran,dpcpp-cpp}-$version
       ;;
     *)
-      sudo apt-get install \
+      sudo apt-get install -y \
         intel-oneapi-compiler-{fortran,dpcpp-cpp-and-cpp-classic}-$version
       ;;
   esac


### PR DESCRIPTION
Currently, if you attempt to use `setup-fortran.sh` on a base Ubuntu image, installing the Intel compilers will currently die as `apt-get install` is run without the `-y` argument (assume yes). All other instances of `apt-get install` in `setup-fortran.sh` have the `-y`. It looks to have been accidentally missed here.

This PR adds in the missing `-y` to allow the intel compiler to be installed in all cases.

Note that it works when running on GitHub Actions' `ubuntu-latest` docker image as that has `apt` configured to always assume yes by default: https://github.com/actions/runner-images/blob/2a8403091c994d6b63e292facecd23b7212c6ccb/images/ubuntu/scripts/build/configure-apt.sh#L20-L21