### PR TITLE
Fix `gcc` install check

### DIFF
--- a/setup-fortran.sh
+++ b/setup-fortran.sh
@@ -45,14 +45,23 @@ install_gcc_brew()
 
 install_gcc_apt()
 {
-  # check if gcc preinstalled via apt
+  # Check whether the system gcc version is the version we are after.
   cur=$(apt show gcc | grep "Version" | cut -d':' -f3 | cut -d'-' -f1)
   maj=$(echo $cur | cut -d'.' -f1)
+  needs_install=1
   if [ "$maj" == "$version" ]; then
-    echo "GCC $version already installed"
+    # Check whether that version is installed.
+    if apt list --installed gcc-${version} | grep -q "gcc-${version}/"; then
+      echo "GCC $version already installed"
+      needs_install=0
+    fi
   else
+    # Install the PPA for installing other versions of gcc.
     sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
     sudo apt-get update
+  fi
+
+  if [ "${needs_install}" == "1" ]; then
     sudo apt-get install -y gcc-${version} gfortran-${version} g++-${version}
   fi
 


### PR DESCRIPTION
Currently, if you attempt to run `setup-fortran.sh` on a base Ubuntu image, if the version of `gcc` that that image is bundled with happens to be the version of `gcc` you want to install, **but** `gcc` hasn't actually been installed yet, this script will fail, as it incorrectly assumes that if the version of gcc in `apt show` matches, that `gcc` is installed. `apt show` only shows you what the packages are; it does not say what is installed. You can check what has been installed via `apt list --installed`.

Example:
```
$ docker run --rm -it ubuntu:24.04
root@e493e172c0d1:/# version=13
root@e493e172c0d1:/# apt-get update
...
Reading package lists...
root@e493e172c0d1:/# cur=$(apt show gcc | grep "Version" | cut -d':' -f3 | cut -d'-' -f1)
root@e493e172c0d1:/# maj=$(echo $cur | cut -d'.' -f1)
root@e493e172c0d1:/# if [ "$maj" == "$version" ]; then echo "GCC $version already installed"; fi
GCC 13 already installed
root@e493e172c0d1:/# update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${version} 100
update-alternatives: error: alternative path /usr/bin/gcc-13 doesn't exist
root@e493e172c0d1:/# gcc
bash: gcc: command not found
root@e493e172c0d1:/# gcc-13
bash: gcc-13: command not found
```

This logic error doesn't present itself when running on GitHub Actions's `ubuntu-latest` image as system gcc is already installed.

This script fixes the logic error in checking whether `gcc` has been installed.