### PR TITLE
version: latest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
       uses: actions/cache/restore@v3
       with:
         path: ${{ env.ONEAPI_ROOT }}
-        key: ${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.version }}-${{ steps.get-date.outputs.date }}
+        key: ${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.version || 'latest' }}-${{ steps.get-date.outputs.date }}
 
     # Use micromamba for lfortran install on mac. Check if micromamba already
     # exists, only install it if needed. If we install it, clean it up after.
@@ -88,7 +88,7 @@ runs:
       uses: actions/cache/save@v3
       with:
         path: ${{ env.ONEAPI_ROOT }}
-        key: ${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.version }}-${{ steps.get-date.outputs.date }}
+        key: ${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.version || 'latest' }}-${{ steps.get-date.outputs.date }}
     - name: Activate oneAPI
       if: runner.os == 'Windows' && contains(inputs.compiler, 'intel')
       shell: cmd

--- a/main.sh
+++ b/main.sh
@@ -13,7 +13,7 @@ source ./setup-fortran.sh
 
 case $compiler in
   gcc)
-    version=${VERSION:-13}
+    version=${VERSION:-latest}
     install_gcc $platform
     ;;
   intel-classic)
@@ -29,7 +29,7 @@ case $compiler in
     install_nvidiahpc $platform
     ;;
   lfortran)
-    version=${VERSION:-0.45.0}
+    version=${VERSION:-latest}
     install_lfortran $platform
     ;;
   *)


### PR DESCRIPTION
Implementation of version: latest parsing, fixes #136 and #33

version: latest is now default for gcc and lfortran installations (since they use package managers) while also defaults to the latest "known" version for intel if explicitly specified in the workflow, e.g.
```
  - uses: fortran-lang/setup-fortran@v1
     with:
       compiler: intel
       version: latest
```
If the version option is not explicitly specified, the updated defaults are now:
```
gcc: latest
lfortran: latest
intel-classic: 2023.2.0 (pinned)
intel: 2025.0 (pinned)
nvidia-hpc: 25.1 (pinned)
```
The main changes to the logic are:

- install_gcc_brew: Uses brew install gcc without version pinning for version: latest
- install_gcc_apt: Installs gcc gfortran g++ without version pinning for version: latest
- install_gcc_choco: Install unpinned gcc via choco install for version: latest
- install_intel_apt: Installs last known version of Intel packages when version: latest, but only if version: latest explicitly specified
- install_lfortran_*: All platforms install unpinned lfortran when latest

Note that the Cache key in action.yml uses ${{ inputs.version || 'latest' }} instead of just ${{ inputs.version }}. This ensures that when no version is specified, it defaults to 'latest' in the cache key. This should prevent cache conflicts between different "latest" installs.