### PR TITLE
fix: use fresh micromamba env for lfortran on all platforms

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,11 +46,15 @@ runs:
         path: ${{ env.ONEAPI_ROOT }}
         key: ${{ runner.os }}-${{ inputs.compiler }}-${{ inputs.version || 'latest' }}-${{ steps.get-date.outputs.date }}
 
-    # Use micromamba for lfortran install on mac. Check if micromamba already
-    # exists, only install it if needed. If we install it, clean it up after.
+    # Use micromamba for lfortran installs, on all platforms: it gives us a
+    # fresh, empty env to install into, rather than the base env baked into
+    # each runner image's pre-installed system conda, which can carry pins
+    # (python, zstd, etc.) that conflict with lfortran's own dependencies.
+    # Check if micromamba already exists, only install it if needed. If we
+    # install it, clean it up after.
     - name: Check for micromamba
       id: check-umamba
-      if: runner.os == 'macOS' && contains(inputs.compiler, 'lfortran')
+      if: contains(inputs.compiler, 'lfortran')
       shell: bash
       run: |
         if [ "$(command -v micromamba)" ]; then
@@ -59,7 +63,7 @@ runs:
           echo "install=true" >> $GITHUB_OUTPUT
         fi
     - uses: mamba-org/setup-micromamba@v3.1.0
-      if: runner.os == 'macOS' && contains(inputs.compiler, 'lfortran') && steps.check-umamba.outputs.install == 'true'
+      if: contains(inputs.compiler, 'lfortran') && steps.check-umamba.outputs.install == 'true'
       with:
         init-shell: bash
         post-cleanup: 'all'

--- a/setup-fortran.sh
+++ b/setup-fortran.sh
@@ -958,7 +958,8 @@ install_lfortran_l()
   local version=$1
   export CC="gcc"
   export CXX="g++"
-  export CONDA=conda
+  export CONDA_ROOT_PREFIX=$MAMBA_ROOT_PREFIX
+  export CONDA=micromamba
   $CONDA install -c conda-forge -n base -y lfortran=$version
 }
 
@@ -967,7 +968,8 @@ install_lfortran_w()
   local version=$1
   export CC="cl"
   export CXX="cl"
-  export CONDA=$CONDA\\Scripts\\conda  # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md#environment-variables
+  export CONDA_ROOT_PREFIX=$MAMBA_ROOT_PREFIX
+  export CONDA=micromamba
   $CONDA install -c conda-forge -n base -y lfortran=$version
 }
 


### PR DESCRIPTION
Windows and Linux installed lfortran into the runner image's pre-existing system conda base env, which carries pins from other already-installed packages. A recent Windows runner image bump pinned `python=3.14` and pulled in newer conda/zstandard builds requiring `zstd>=1.5.7`, which conflicts with lfortran's `zstd=1.5.6` pin.

Use micromamba (as macOS already does) on every platform, so lfortran always installs into a fresh, empty env