### PR TITLE
fix: build expected paths in tests the same way the source builds them

### DIFF
--- a/__tests__/bash_env.test.ts
+++ b/__tests__/bash_env.test.ts
@@ -1,14 +1,24 @@
 import * as core from "@actions/core";
 import * as fs from "fs";
+import * as path from "path";
 import { persistBinDirForBash, toMsysPath } from "../src/bash_env";
 
 jest.mock("@actions/core");
 jest.mock("fs");
 
 describe("persistBinDirForBash", () => {
+  const runnerTemp = "D:\\a\\_temp";
+  // Built the same way persistBinDirForBash builds it (plain path.join),
+  // so this matches regardless of whether the test runs on Linux CI or a
+  // native Windows machine: both sides track the same host OS.
+  const lfortranBashEnvPath = path.join(
+    runnerTemp,
+    "setup-fortran-lfortran-bash-env.sh",
+  );
+
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env.RUNNER_TEMP = "D:\\a\\_temp";
+    process.env.RUNNER_TEMP = runnerTemp;
     delete process.env.BASH_ENV;
   });
 
@@ -23,37 +33,41 @@ describe("persistBinDirForBash", () => {
       "lfortran",
     );
 
-    expect(bashEnv).toBe("D:\\a\\_temp/setup-fortran-lfortran-bash-env.sh");
+    expect(bashEnv).toBe(lfortranBashEnvPath);
     expect(fs.writeFileSync).toHaveBeenCalledWith(
-      "D:\\a\\_temp/setup-fortran-lfortran-bash-env.sh",
+      lfortranBashEnvPath,
       `export PATH='/c/hostedtoolcache/setup-fortran/lfortran/win32/x64/0.64.0/env/Library/bin':"$PATH"\n`,
       { mode: 0o600 },
     );
     expect(core.exportVariable).toHaveBeenCalledWith(
       "BASH_ENV",
-      "/d/a/_temp/setup-fortran-lfortran-bash-env.sh",
+      toMsysPath(lfortranBashEnvPath),
     );
   });
 
   it("chains a Bash environment written by another installer", () => {
-    process.env.BASH_ENV = "D:\\a\\_temp\\setup-fortran-msvc-bash-env.sh";
+    const previousBashEnv = path.join(
+      runnerTemp,
+      "setup-fortran-msvc-bash-env.sh",
+    );
+    process.env.BASH_ENV = previousBashEnv;
 
     persistBinDirForBash("C:\\MSVC\\bin", "lfortran");
 
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       expect.any(String),
-      `. '/d/a/_temp/setup-fortran-msvc-bash-env.sh'\nexport PATH='/c/MSVC/bin':"$PATH"\n`,
+      `. '${toMsysPath(previousBashEnv)}'\nexport PATH='/c/MSVC/bin':"$PATH"\n`,
       { mode: 0o600 },
     );
   });
 
   it("does not source itself when the same installer runs twice", () => {
-    process.env.BASH_ENV = "/d/a/_temp/setup-fortran-lfortran-bash-env.sh";
+    process.env.BASH_ENV = toMsysPath(lfortranBashEnvPath);
 
     persistBinDirForBash("C:\\MSVC\\bin", "lfortran");
 
     expect(fs.writeFileSync).toHaveBeenCalledWith(
-      "D:\\a\\_temp/setup-fortran-lfortran-bash-env.sh",
+      lfortranBashEnvPath,
       `export PATH='/c/MSVC/bin':"$PATH"\n`,
       { mode: 0o600 },
     );

--- a/__tests__/installers/gfortran/win32.test.ts
+++ b/__tests__/installers/gfortran/win32.test.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 import * as tc from "@actions/tool-cache";
+import * as path from "path";
 import { installWin32 } from "../../../src/installers/gfortran/win32";
 import { setupMSYS2 } from "../../../src/setup_msys2";
 import { verifySha256 } from "../../../src/verify_download";
@@ -49,19 +50,33 @@ describe("installWin32 (gfortran)", () => {
 
   describe("Native", () => {
     it("downloads and extracts GFortran", async () => {
+      const cacheDir = "C:\\Cache\\gfortran";
+      const downloadedZip = "C:\\Temp\\gcc.zip";
+      const extractedDir = "C:\\Temp\\extracted";
       mockedTc.find.mockReturnValue("");
-      mockedTc.downloadTool.mockResolvedValue("C:\\Temp\\gcc.zip");
-      mockedTc.extractZip.mockResolvedValue("C:\\Temp\\extracted");
-      mockedTc.cacheDir.mockResolvedValue("C:\\Cache\\gfortran");
+      mockedTc.downloadTool.mockResolvedValue(downloadedZip);
+      mockedTc.extractZip.mockResolvedValue(extractedDir);
+      mockedTc.cacheDir.mockResolvedValue(cacheDir);
 
       const result = await installWin32(baseInputs);
 
-      expect(result.fc).toBe("C:\\Cache\\gfortran/bin/gfortran.exe");
-      expect(result.cc).toBe("C:\\Cache\\gfortran/bin/gcc.exe");
-      expect(result.cxx).toBe("C:\\Cache\\gfortran/bin/g++.exe");
+      // Built the same way installWin32 builds it (plain path.join), so
+      // this matches regardless of whether the test runs on Linux CI or a
+      // native Windows machine: both sides track the same host OS.
+      const binDir = path.join(cacheDir, "bin");
+      expect(result.fc).toBe(path.join(binDir, "gfortran.exe"));
+      expect(result.cc).toBe(path.join(binDir, "gcc.exe"));
+      expect(result.cxx).toBe(path.join(binDir, "g++.exe"));
       expect(mockedTc.downloadTool).toHaveBeenCalled();
-      expect(mockedTc.extractZip).toHaveBeenCalledWith("C:\\Temp\\gcc.zip");
-      expect(mockedTc.cacheDir).toHaveBeenCalled();
+      expect(mockedTc.extractZip).toHaveBeenCalledWith(downloadedZip);
+      // Verifies the "mingw64" subdirectory installWin32 appends before
+      // caching, not just that cacheDir was called at all.
+      expect(mockedTc.cacheDir).toHaveBeenCalledWith(
+        path.join(extractedDir, "mingw64"),
+        `gfortran-verified-${baseInputs.msystem}`,
+        baseInputs.version,
+        baseInputs.arch,
+      );
       expect(core.addPath).toHaveBeenCalledWith(expect.stringContaining("bin"));
     });
 

--- a/__tests__/setup_msvc.test.ts
+++ b/__tests__/setup_msvc.test.ts
@@ -1,5 +1,6 @@
 import * as core from "@actions/core";
 import * as fs from "fs";
+import * as path from "path";
 import {
   addMsvcBinFromPath,
   persistMsvcBinForBash,
@@ -10,9 +11,18 @@ jest.mock("@actions/core");
 jest.mock("fs");
 
 describe("addMsvcBinFromPath", () => {
+  const runnerTemp = "D:\\a\\_temp";
+  // Built the same way persistMsvcBinForBash builds it (plain path.join),
+  // so this matches regardless of whether the test runs on Linux CI or a
+  // native Windows machine: both sides track the same host OS.
+  const msvcBashEnvPath = path.join(
+    runnerTemp,
+    "setup-fortran-msvc-bash-env.sh",
+  );
+
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env.RUNNER_TEMP = "D:\\a\\_temp";
+    process.env.RUNNER_TEMP = runnerTemp;
     delete process.env.BASH_ENV;
   });
 
@@ -31,7 +41,7 @@ describe("addMsvcBinFromPath", () => {
     expect(core.addPath).toHaveBeenCalledWith(msvcBin);
     expect(core.exportVariable).toHaveBeenCalledWith(
       "BASH_ENV",
-      "/d/a/_temp/setup-fortran-msvc-bash-env.sh",
+      toMsysPath(msvcBashEnvPath),
     );
   });
 
@@ -47,11 +57,9 @@ describe("addMsvcBinFromPath", () => {
     const msvcBin =
       "C:\\Program Files\\Microsoft Visual Studio\\18\\Enterprise\\VC\\Tools\\MSVC\\14.51.36231\\bin\\HostX64\\x64";
 
-    expect(persistMsvcBinForBash(msvcBin)).toBe(
-      "D:\\a\\_temp/setup-fortran-msvc-bash-env.sh",
-    );
+    expect(persistMsvcBinForBash(msvcBin)).toBe(msvcBashEnvPath);
     expect(fs.writeFileSync).toHaveBeenCalledWith(
-      "D:\\a\\_temp/setup-fortran-msvc-bash-env.sh",
+      msvcBashEnvPath,
       `export PATH='/c/Program Files/Microsoft Visual Studio/18/Enterprise/VC/Tools/MSVC/14.51.36231/bin/HostX64/x64':"$PATH"\n`,
       { mode: 0o600 },
     );
@@ -70,7 +78,7 @@ describe("addMsvcBinFromPath", () => {
   });
 
   it("does not source itself when setup runs more than once", () => {
-    process.env.BASH_ENV = "/d/a/_temp/setup-fortran-msvc-bash-env.sh";
+    process.env.BASH_ENV = toMsysPath(msvcBashEnvPath);
 
     persistMsvcBinForBash("C:\\MSVC\\bin");
 

--- a/__tests__/setup_msvc_bash.test.ts
+++ b/__tests__/setup_msvc_bash.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { persistMsvcBinForBash } from "../src/setup_msvc";
+import { persistMsvcBinForBash, toMsysPath } from "../src/setup_msvc";
 
 jest.mock("@actions/core");
 
@@ -45,7 +45,14 @@ describe("persistMsvcBinForBash shell integration", () => {
     );
 
     expect(firstPathEntry).toBe(msvcBin);
-    expect(core.exportVariable).toHaveBeenCalledWith("BASH_ENV", bashEnv);
+    // The exported BASH_ENV is msys-converted (toMsysPath) so Git Bash can
+    // source it; the returned bashEnv is the native path used internally
+    // (e.g. by fs.writeFileSync) and only equals the exported value on
+    // POSIX, where toMsysPath is a no-op.
+    expect(core.exportVariable).toHaveBeenCalledWith(
+      "BASH_ENV",
+      toMsysPath(bashEnv),
+    );
   });
 
   it("sources a pre-existing Bash environment before adding the tool path", () => {


### PR DESCRIPTION
## Summary

Closes #253.

Four test files targeting Windows-only code paths hardcoded expected path strings that mix forward and back slashes (e.g. `"D:\\a\\_temp/setup-fortran-msvc-bash-env.sh"`). Those literals only match what Node's platform-dependent `path.join` produces when the test itself runs on Linux, where `path.join` treats embedded backslashes as ordinary characters and joins with `/`. Since CI (`validation.yml`) only runs `npm test` on `ubuntu-latest`, that mismatch has never been caught — but running the suite on an actual Windows machine, where `path.join` correctly normalizes everything to backslashes, produces `expect` failures in tests that exist specifically to cover Windows behavior.

One additional case in `setup_msvc_bash.test.ts` was a different bug: the test asserted that the value passed to `core.exportVariable("BASH_ENV", ...)` equals the raw return value of `persistMsvcBinForBash`. That assumption only holds on POSIX. On Windows those two values are meant to differ — the return value is a native path (used internally, e.g. for `fs.writeFileSync`), while the exported `BASH_ENV` is deliberately converted to a Git-Bash-style path (via `toMsysPath`) so a non-interactive Bash step can actually source it. The test was fixed to assert against `toMsysPath(bashEnv)`, matching what the source already does.

## Changes

- `__tests__/setup_msvc.test.ts`, `__tests__/bash_env.test.ts`, `__tests__/installers/gfortran/win32.test.ts` — replaced hardcoded mixed-separator literals with `path.join(...)` calls built the same way the corresponding source function builds them (plain `path.join`, not `path.win32.join`). A first pass at this fix used `path.win32.join`, which forces Windows-style separators unconditionally — but since the source under test still uses plain, host-OS-dependent `path.join`, that would have fixed Windows while breaking these same assertions on Linux CI. Using plain `path.join` on both sides means the expected and actual values are always computed the same way, so they agree regardless of which OS actually runs the test.
- `__tests__/setup_msvc_bash.test.ts` — asserted `toMsysPath(bashEnv)` instead of the raw native-path return value.
- Follow-up cleanup in the same files, once the above was in place: several tests independently retyped the same literal in more than one place (e.g. the fake `RUNNER_TEMP` value, a mocked cache directory) with nothing tying the copies together, so an edit to one could silently drift from the other without either test catching it. Hoisted each of those to a single local constant (`runnerTemp`, `lfortranBashEnvPath`, `msvcBashEnvPath`, per-test mock values like `cacheDir`/`downloadedZip`) that every place needing the value now references instead of retyping. No behavior change — purely removing duplication that had nothing to do with the original bug.
- `__tests__/installers/gfortran/win32.test.ts` — added a missing assertion: `expect(mockedTc.cacheDir).toHaveBeenCalledWith(...)` only checked that `cacheDir` was called at all, not with what. Added the actual expected arguments, including the `"mingw64"` subdirectory `installWin32` appends before caching. Verified this actually catches a regression: temporarily changed the source's subdirectory literal and confirmed the test fails with a clear diff, then reverted.

No other changes to `src/`.

## Testing

Ran the full suite locally on native Windows (Node 24.19.0, per `.nvmrc`):

- The four modified files: 16/16 tests pass (previously 5 failing).
- Full `npm test`: 688/702 pass. The remaining 14 failures across 6 suites (`installers/{aocc,armflang,nvfortran}/debian.test.ts`, `installers/{gfortran,flang}/darwin.test.ts`, `installers/lfortran/debian.test.ts`) are the unrelated Windows exec-mocking issue tracked separately in #254 — untouched by this PR.
- `npx tsc --noEmit`: clean.
- `npm run lint` (eslint on `src/**/*.ts`): clean.
- `npx prettier --check` on the four modified files: clean.
- The new `cacheDir` assertion and the earlier `path.win32.join` mistake were each verified empirically (deliberately breaking the relevant source line and confirming the test fails, then reverting) rather than trusted from reasoning alone.

No Linux/macOS machine was available to run the suite there directly, so before opening this PR the fix was pushed to a branch on my own fork and run through this repo's actual `validation` workflow there (not just reasoned about). On `ubuntu-latest`, all four modified files pass (`PASS __tests__/setup_msvc.test.ts`, `bash_env.test.ts`, `setup_msvc_bash.test.ts`, `installers/gfortran/win32.test.ts`), and the full suite reports `Tests: 702 passed, 702 total` — i.e. every test that fails locally on Windows for the unrelated #254 issue passes here on Linux, which is expected since #254 is Windows-only. CI on this PR against the real repo will be the authoritative confirmation.

## Compatibility

Test-only change; no production code touched, no behavior change for users of the action.

Drafted with Claude's assistance.
- Root cause verified by reading the actual test failures on a real Windows machine and tracing them to Node's platform-dependent `path.join` semantics in the test files, not assumed from the issue description alone.
- An initial version of this fix used `path.win32.join`, which was caught as incorrect (would break Linux CI) by directly computing `path.win32.join` vs. `path.posix.join` output for the same inputs and comparing — not just re-reading the diff. Corrected to plain `path.join` before opening this PR.
- The new `cacheDir` assertion was verified to actually catch a regression by deliberately breaking the source and confirming the test failed, not just added and assumed correct.
- Every assertion changed was re-verified by rerunning the affected test file and the full suite after each edit, not just visually inspected.
- The Linux-CI claim above is a real GitHub Actions run against the actual commit (verified by checking the run's head SHA matched), not a job that merely reported success without confirming it ran — the job log was pulled directly and the four files' `PASS` lines and the `702 passed, 702 total` summary were read from it, not inferred from job status alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
